### PR TITLE
Add notes for retrieving subnet IP

### DIFF
--- a/docs/application-hosting/applications/ombi.mdx
+++ b/docs/application-hosting/applications/ombi.mdx
@@ -38,6 +38,8 @@ If you have further questions about settings and configurations of Ombi, please 
 
 ## Connect to other clients
 
+> To get your subnet IP, SSH into your server and run `cat .install/subnet.lock`
+
 ### Sonarr
 
 :::panel

--- a/docs/application-hosting/snippets/clients.mdx
+++ b/docs/application-hosting/snippets/clients.mdx
@@ -44,7 +44,7 @@ SSL: OFF"
   <TabItem value="qbittorrent">
     <CodeBlock
       children="Name: qBittorrent
-Host: <subnet ip> (In older cases: 127.0.0.1)
+Host: <subnet ip> (In older cases: 127.0.0.1 - you can get your subnet IP by SSH'ing into your server and running `cat .install/subnet.lock`)
 Post: <qbittorrent web port>
 Username: <your username>
 Password: <your password>


### PR DESCRIPTION
This change adds some helper notes in areas where the subnet IP is mentioned. 

Open to improvements on formatting or wording or any missed cases where this could be of use! 