### PR TITLE
Fixes wrong app name

### DIFF
--- a/docs/application-hosting/applications/bazarr.mdx
+++ b/docs/application-hosting/applications/bazarr.mdx
@@ -78,7 +78,7 @@ cat ~/.install/subnet.lock
 Sonarr:
 
 ```bash
-cat ~/.config/NzbDrone/config.xml | grep -e \<Api -e \<Port
+cat ~/.config/Sonarr/config.xml | grep -e \<Api -e \<Port
 ```
 
 Radarr:


### PR DESCRIPTION
The app name was wrong in the command making it fail if you would copy/paste