### PR TITLE
Add and adopt subnet component

### DIFF
--- a/docs/application-hosting/applications/bazarr.mdx
+++ b/docs/application-hosting/applications/bazarr.mdx
@@ -4,6 +4,9 @@ title: Bazarr
 sidebar_label: Bazarr
 ---
 
+import Subnet from '../snippets/subnet.mdx';
+import SystemdTabs from "../snippets/systemdtabs.mdx";
+
 Bazarr is a companion application to Sonarr and Radarr. It manages and downloads subtitles based on your requirements. You define your preferences by TV show or movie and Bazarr takes care of everything for you.
 
 ## Initial Setup
@@ -28,8 +31,6 @@ Once setup, bazarr will be available at the link `https://<hostname.io>/bazarr`
 ## Service Management
 
 Like all box configured applications, you can manage Bazarr via SSH with box with start, stop, restart, enable and disable commands.
-
-import SystemdTabs from "../snippets/systemdtabs.mdx";
 
 <SystemdTabs service="bazarr" />
 
@@ -69,14 +70,10 @@ Base URL: /radarr
 API Key: <radarr API>
 ```
 
+<Subnet/>
+
 :::tip Tip
-Forgot your subnet, API key or port? No worries, here are oneliners you can submit from SSH:
-
-Subnet:
-
-```bash
-cat ~/.install/subnet.lock
-```
+Forgot your API key or port? No worries, here are oneliners you can submit from SSH:
 
 Sonarr:
 

--- a/docs/application-hosting/applications/ombi.mdx
+++ b/docs/application-hosting/applications/ombi.mdx
@@ -4,6 +4,9 @@ title: Ombi
 sidebar_label: Ombi
 ---
 
+import Subnet from '../snippets/subnet.mdx';
+import SystemdTabs from "../snippets/systemdtabs.mdx";
+
 Ombi is a self-hosted web application that automatically gives your shared Plex or Emby users the ability to request content by themselves! Ombi can be linked to multiple TV Show and Movie DVR tools to create a seamless end-to-end experience for your users.
 
 ## Initial Setup
@@ -26,8 +29,6 @@ After installation, Ombi will be availabe at the following web address: `https:/
 
 Like all box configured applications, you can manage Ombi via SSH with box with start, stop, restart, enable and disable commands.
 
-import SystemdTabs from "../snippets/systemdtabs.mdx";
-
 <SystemdTabs service="ombi" />
 
 ## Configuration
@@ -38,11 +39,9 @@ If you have further questions about settings and configurations of Ombi, please 
 
 ## Connect to other clients
 
-> To get your subnet IP, SSH into your server and run `cat .install/subnet.lock`
+<Subnet />
 
 ### Sonarr
-
-:::panel
 
 1. Select Sonarr from the TV Dropdown under settings.
 2. In order to configure Sonarr, you must first have a root folder setup. If you haven't set up any root folders in Sonarr, please add a show and setup your Sonarr root show directory first.
@@ -60,11 +59,7 @@ Base URL: sonarr
 5. Choose your default quality and folder settings for shows added through Ombi.
 6. Submit
 
-:::
-
 ### Medusa
-
-:::panel
 
 1. Select SickRage from the TV Dropdown under settings.
 2. Use the following configuration:
@@ -79,11 +74,8 @@ Base URL: medusa
 
 3. Choose a default quality profile.
 4. Submit
-   :::
 
 ### Radarr
-
-:::panel
 
 1. Select Radarr from the Movie Dropdown under settings.
 2. In order to configure Radarr, you must first have a root folder setup. If you haven't set up any root folders in Radarr, please add a show and setup your Sonarr root show directory first.
@@ -100,9 +92,3 @@ Base URL: radarr
 4. Click `Load Qualities` and `Load Folders`. Your settings should load successfully.
 5. Choose your default quality and folder settings for Movies added through Ombi.
 6. Submit
-
-:::
-
-:::tip
-In order to connect Ombi to the clients above, you'll need your subnet IP. You can find this on your panel or with the command `cat ~/.install/subnet.lock`
-:::

--- a/docs/application-hosting/applications/prowlarr.mdx
+++ b/docs/application-hosting/applications/prowlarr.mdx
@@ -45,7 +45,11 @@ Out of the box, Prowlarr comes with very little configuration. Following are som
 
 ### Connect download clients
 
-First, navigate to the settings page in the sidebar, then click "Download Clients". Client specific info is available below. You may need to know your subnet to configure correctly. You may retrieve this by logging into your slot via ssh and entering the command `cat $HOME/.install/subnet.lock` or by going to the general menu in prowlarr, clicking "show advanced", then look at the bind address.
+First, navigate to the settings page in the sidebar, then click "Download Clients". Client specific info is available below. You may need to know your subnet to configure correctly. You may retrieve this by following the below tip or by going to the general menu in prowlarr, clicking "show advanced", then look at the bind address.
+
+import Subnet from '../snippets/subnet.mdx';
+
+<Subnet />
 
 import Clients from "../snippets/clients.mdx";
 
@@ -62,7 +66,7 @@ You need to know your subnet to configure correctly. Go to the Settings -> Gener
 3. Under "Applications", click the + button.
 4. Select the application you wish to sync your indexers to.
 5. Enter the subnet ip like the following for prowlarr:
-    - `http://subnet:port/prowlarr/
+    - `http://subnet:port/prowlarr/`
 6. Enter the subnet ip like the following for any of the supported apps you have installed via box:
-    - `http://subnet:port/appname/
+    - `http://subnet:port/appname/`
 7. Repeat as neccesary.

--- a/docs/application-hosting/applications/wireguard.mdx
+++ b/docs/application-hosting/applications/wireguard.mdx
@@ -50,8 +50,6 @@ Wireguard is available on many platforms. Setting it up for use with your Hostin
 
 #### Linux / OS X
 
-:::panel
-
 1. Simply copy-paste the configuration file outputted at the end of the server setup into a file in /etc/wireguard.
 
 ```bash
@@ -69,22 +67,16 @@ sudo wg-quick up wg0
 sudo systemctl enable wg-quick@wg0
 ```
 
-:::
-
 #### Windows
-
-:::panel
 
 1. Copy-paste the contents of the client configuration outputted at the end of configuration into a file onto your local desktop,eg: `HostingByDesign.conf.d`
 
 2. Open TunSafe, click and drag the configuration file you just created to the TunSafe window. TunSafe will automatically import the client configuration and connect. Easy!
 
 3. [Check your IP Address](https://duckduckgo.com/?q=ip+address&ia=answer). It should now reflect your shared or dedicated IP for your slot.
-   :::
 
 #### Android
 
-:::panel
 Configuration is easiest if you use utilize the QR Encode function.
 
 1. Connect to your server from a computer and issue the commands:
@@ -97,11 +89,9 @@ qrencode -t ansiutf8 < ~/.wireguard/$u.conf
 2. In your client on your phone, add a new tunnel and chose the `QR Code` option. Scan the QR code which was generated in your terminal.
 3. Enable the tunnel by ticking the switch.
 4. [Check your IP Address](https://duckduckgo.com/?q=ip+address&ia=answer).
-   :::
 
 #### iOS
 
-:::panel
 Configuration is easiest if you use utilize the QR Encode function.
 
 1. Connect to your server from a computer and issue the commands:
@@ -114,7 +104,6 @@ qrencode -t ansiutf8 < ~/.wireguard/$u.conf
 2. In your client on your phone, add a new tunnel and chose the `QR Code` option. Scan the QR code which was generated in your terminal.
 3. Enable the tunnel by ticking the switch.
 4. [Check your IP Address](https://duckduckgo.com/?q=ip+address&ia=answer).
-   :::
 
 ## Service Management
 

--- a/docs/application-hosting/snippets/subnet.mdx
+++ b/docs/application-hosting/snippets/subnet.mdx
@@ -1,0 +1,6 @@
+:::tip Tip
+To get your subnet IP, SSH into your server and run:
+
+```bash
+cat ~/.install/subnet.lock
+```


### PR DESCRIPTION
This change adds a subnet component (a tip admonition that explains how to get the subnet IP) and adopts it across most use cases (the only exceptions are other components as I haven't quite gotten around to figuring that out).

In addition, clean up non-working :::panel admonitions in some documents

This is a rework of #36.